### PR TITLE
Update spacy.gold to offsets_to_biluo_tags

### DIFF
--- a/doccano_transformer/examples.py
+++ b/doccano_transformer/examples.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from typing import Callable, Iterator, List, Optional
 
-from spacy.gold import biluo_tags_from_offsets
+from spacy.training import offsets_to_biluo_tags
 
 from doccano_transformer import utils
 
@@ -98,7 +98,7 @@ class NERExample:
                 tokens = utils.convert_tokens_and_offsets_to_spacy_tokens(
                     tokens, offsets
                 )
-                tags = biluo_tags_from_offsets(tokens, label)
+                tags = offsets_to_biluo_tags(tokens, label)
                 tokens_for_spacy = []
                 for i, (token, tag, offset) in enumerate(
                     zip(tokens, tags, offsets)


### PR DESCRIPTION
# Description

This suggestion updates the `spacy` methods in order to use latest package version available. According to [this documentation](https://spacy.io/usage/v3), `spacy.gold` was replaced by `spacy.training` with different method signatures.

Fixes #35 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Exported a `.jsonl` dataset from doccano and converted to `spacy()` format. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
